### PR TITLE
Feature/outer mw 202605

### DIFF
--- a/configs/netflow/SSP/CC/crosscalib_common.py
+++ b/configs/netflow/SSP/CC/crosscalib_common.py
@@ -25,6 +25,7 @@ config = dict(
         black_dot_penalty = R'lambda dist: 10 / (dist + 1)',
         cobra_move_cost = R'lambda dist: 5 * dist',
         collision_distance = 2.0,
+        cobra_safety_margin = 0.1, # mm
         forbidden_targets = [],
         forbidden_pairs = [],
         science_prefix = ['sci', 'cal'],

--- a/configs/netflow/SSP/CC/crosscalib_ra288_dec-11.py
+++ b/configs/netflow/SSP/CC/crosscalib_ra288_dec-11.py
@@ -3,10 +3,10 @@ from datetime import datetime
 DATA_DIR = '$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_ra288_dec-11'
 
 # TODO: update these IDs
-PROPOSALID = 'S25A-OT02'
+PROPOSALID = 'S26A-OT02'
 CATID_SKY_GAIA = 1006
 CATID_SKY_PS1 = 1007
-CATID_FLUXSTD = 3006
+CATID_FLUXSTD = 3012
 CATID_SCIENCE_CO = 10091
 CATID_SCIENCE_GA = 10092
 CATID_SCIENCE_GE = 10093
@@ -36,11 +36,11 @@ config = dict(
     field = dict(
         key = "crosscalib_ra288_decm11",
         name = "Cross-Calibration ra=288 dec=-11",
-        obs_time = datetime(2025, 6, 1, 15, 0, 0),
+        obs_time = datetime(2026, 5, 15, 15, 0, 0),
         id_prefix = ID_PREFIX
     ),
     pointings = [
-        dict(ra=288.35, dec=-11.45, posang=0.0, priority=200),
+        dict(ra=288.35, dec=-11.45, posang=0.0, priority=9),
     ],
     targets = {
         # Miho
@@ -205,7 +205,7 @@ config = dict(
                 'pmdec': 'pmdec',
                 'pmdec_error': 'err_pmdec',
             },
-            mask = 'lambda df: df["prob_f_star"] > 0.5',
+            mask = 'lambda df: df["is_fstar_gaia"] == True',
             prefix = "cal",
             catid = CATID_FLUXSTD,
             extra_columns = {
@@ -229,9 +229,9 @@ config = dict(
                         psf_flux_err = f'psf_flux_error_{b}',
                     ) for b in 'grizy'
                 },
-                # limits = {
-                #     'ps1_g': [16.5, 18.5],
-                # }
+                #limits = {
+                #     'ps1_g': [13.5, 18.5],
+                #}
             )
         ),
     },

--- a/configs/netflow/SSP/CC/crosscalib_ra288_dec-17.py
+++ b/configs/netflow/SSP/CC/crosscalib_ra288_dec-17.py
@@ -3,10 +3,10 @@ from datetime import datetime
 DATA_DIR = '$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_ra288_dec-17'
 
 # TODO: update these IDs
-PROPOSALID = 'S25A-OT02'
+PROPOSALID = 'S26A-OT02'
 CATID_SKY_GAIA = 1006
 CATID_SKY_PS1 = 1007
-CATID_FLUXSTD = 3006
+CATID_FLUXSTD = 3012
 CATID_SCIENCE_CO = 10091
 CATID_SCIENCE_GA = 10092
 CATID_SCIENCE_GE = 10093
@@ -36,7 +36,7 @@ config = dict(
     field = dict(
         key = "crosscalib_ra288_decm17",
         name = "Cross-Calibration ra=288 dec=-17",
-        obs_time = datetime(2025, 6, 1, 15, 0, 0),
+        obs_time = datetime(2026, 5, 15, 15, 0, 0),
         id_prefix = ID_PREFIX
     ),
     pointings = [
@@ -205,7 +205,7 @@ config = dict(
                 'pmdec': 'pmdec',
                 'pmdec_error': 'err_pmdec',
             },
-            mask = 'lambda df: df["prob_f_star"] > 0.5',
+            mask = 'lambda df: df["is_fstar_gaia"] == True',
             prefix = "cal",
             catid = CATID_FLUXSTD,
             extra_columns = {
@@ -229,9 +229,9 @@ config = dict(
                         psf_flux_err = f'psf_flux_error_{b}',
                     ) for b in 'grizy'
                 },
-                # limits = {
-                #     'ps1_g': [16.5, 18.5],
-                # }
+                #limits = {
+                #     'ps1_g': [13.5, 17.5],
+                #}
             )
         ),
     },

--- a/configs/netflow/SSP/CC/crosscalib_ra288_dec-22.py
+++ b/configs/netflow/SSP/CC/crosscalib_ra288_dec-22.py
@@ -3,10 +3,10 @@ from datetime import datetime
 DATA_DIR = '$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_ra288_dec-22'
 
 # TODO: update these IDs
-PROPOSALID = 'S25A-OT02'
+PROPOSALID = 'S26A-OT02'
 CATID_SKY_GAIA = 1006
 CATID_SKY_PS1 = 1007
-CATID_FLUXSTD = 3006
+CATID_FLUXSTD = 3012
 CATID_SCIENCE_CO = 10091
 CATID_SCIENCE_GA = 10092
 CATID_SCIENCE_GE = 10093
@@ -36,7 +36,7 @@ config = dict(
     field = dict(
         key = "crosscalib_ra288_decm22",
         name = "Cross-Calibration ra=288 dec=-22",
-        obs_time = datetime(2025, 6, 1, 15, 0, 0),
+        obs_time = datetime(2026, 5, 15, 15, 0, 0),
         id_prefix = ID_PREFIX
     ),
     pointings = [
@@ -205,7 +205,7 @@ config = dict(
                 'pmdec': 'pmdec',
                 'pmdec_error': 'err_pmdec',
             },
-            mask = 'lambda df: df["prob_f_star"] > 0.5',
+            mask = 'lambda df: df["is_fstar_gaia"] == True',
             prefix = "cal",
             catid = CATID_FLUXSTD,
             extra_columns = {
@@ -230,7 +230,7 @@ config = dict(
                     ) for b in 'grizy'
                 },
                 # limits = {
-                #     'ps1_g': [16.5, 18.5],
+                #     'ps1_g': [13.5, 18.5],
                 # }
             )
         ),

--- a/configs/netflow/SSP/CC/crosscalib_ra336_dec-12.py
+++ b/configs/netflow/SSP/CC/crosscalib_ra336_dec-12.py
@@ -3,10 +3,10 @@ from datetime import datetime
 DATA_DIR = '$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_ra336_dec-12'
 
 # TODO: update these IDs
-PROPOSALID = 'S25A-OT02'
+PROPOSALID = 'S26A-OT02'
 CATID_SKY_GAIA = 1006
 CATID_SKY_PS1 = 1007
-CATID_FLUXSTD = 3006
+CATID_FLUXSTD = 3012
 CATID_SCIENCE_CO = 10091
 CATID_SCIENCE_GA = 10092
 CATID_SCIENCE_GE = 10093
@@ -36,7 +36,7 @@ config = dict(
     field = dict(
         key = "crosscalib_ra336_decm12",
         name = "Cross-Calibration ra=336 dec=-12",
-        obs_time = datetime(2025, 6, 1, 15, 0, 0),
+        obs_time = datetime(2026, 5, 15, 15, 0, 0),
         id_prefix = ID_PREFIX
     ),
     pointings = [
@@ -205,7 +205,7 @@ config = dict(
                 'pmdec': 'pmdec',
                 'pmdec_error': 'err_pmdec',
             },
-            mask = 'lambda df: df["prob_f_star"] > 0.5',
+            mask = 'lambda df: df["prob_f_star"] > 0.5 ',
             prefix = "cal",
             catid = CATID_FLUXSTD,
             extra_columns = {
@@ -229,9 +229,9 @@ config = dict(
                         psf_flux_err = f'psf_flux_error_{b}',
                     ) for b in 'grizy'
                 },
-                # limits = {
-                #     'ps1_g': [16.5, 18.5],
-                # }
+                limits = {
+                     'ps1_g': [13.0, 20.0],
+                }
             )
         ),
     },

--- a/configs/netflow/SSP/MW/outerdisk_l90_b25.py
+++ b/configs/netflow/SSP/MW/outerdisk_l90_b25.py
@@ -39,7 +39,7 @@ config = dict(
         id_prefix = ID_PREFIX
     ),
     pointings = [
-        dict(ra=279.0145, dec=60.467667, posang=0.0, priority=9),
+        dict(ra=279.0145, dec=60.467667, posang=120.0, priority=9),
     ],
     targets = {
         # # Federico

--- a/configs/netflow/SSP/MW/outerdisk_l90_b27.py
+++ b/configs/netflow/SSP/MW/outerdisk_l90_b27.py
@@ -40,7 +40,7 @@ config = dict(
         id_prefix = ID_PREFIX
     ),
     pointings = [
-        dict(ra=276.28191, dec=60.70011, posang=0.0, priority=9),
+        dict(ra=276.28191, dec=60.70011, posang=120.0, priority=9),
     ],
     targets = {
         # # Federico

--- a/configs/netflow/SSP/MW/outerhalo_l179_b60.py
+++ b/configs/netflow/SSP/MW/outerhalo_l179_b60.py
@@ -40,7 +40,7 @@ config = dict(
         id_prefix = ID_PREFIX
     ),
     pointings = [
-        dict(ra=159.9902297310862, dec=39.86885857947008, posang=0.0, priority=9),
+        dict(ra=159.9902297310862, dec=39.86885857947008, posang=300.0, priority=9),
     ],
     netflow_options = dict(
        cobra_groups = {

--- a/configs/netflow/SSP/MW/outerhalo_l181_b60.py
+++ b/configs/netflow/SSP/MW/outerhalo_l181_b60.py
@@ -40,7 +40,7 @@ config = dict(
         id_prefix = ID_PREFIX
     ),
     pointings = [
-        dict(ra=159.78134526754184, dec=39.239137634010305, posang=0.0, priority=9),
+        dict(ra=159.78134526754184, dec=39.239137634010305, posang=300.0, priority=9),
     ],
     netflow_options = dict(
        cobra_groups = {

--- a/scripts/ssp_202605_crosscalib.sh
+++ b/scripts/ssp_202605_crosscalib.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+
+PREFIX=SSP
+VERSION="000"
+
+NVISITS=1
+NFRAMES=2
+EXP_TIME=300
+OBS_TIME="2026-06-01T15:00:00"          # UTC
+OBS_RUN="2026-05"
+PROPOSAL_ID="S25A-OT02"
+INPUT_CATALOG_ID="10092"
+
+SSP_OBS_PATH="/home/dobos/project/Subaru-PFS/spt_ssp_observation"
+
+# EXTRA_OPTIONS="--debug"
+EXTRA_OPTIONS=""
+
+#FIELDS="ra288_dec-11 ra288_dec-17 ra288_dec-22 ra336_dec-12"
+FIELDS="ra336_dec-12"
+
+for FIELD in $FIELDS; do
+
+     FIELD_DIR=$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_${FIELD}
+     IMPORT_DIR=${FIELD_DIR}/import/crosscalib_${FIELD}_${PREFIX}_${VERSION}
+     NETFLOW_DIR=${FIELD_DIR}/netflow/crosscalib_${FIELD}_${NVISITS}_${PREFIX}_${VERSION}
+     EXPORT_DIR=${FIELD_DIR}/export/crosscalib_${FIELD}_${NVISITS}_${PREFIX}_${VERSION}
+
+     rm -Rf "${IMPORT_DIR}"
+     rm -Rf "${NETFLOW_DIR}"
+     rm -Rf "${EXPORT_DIR}"
+
+     if [ ! -d "$IMPORT_DIR" ]; then
+         ga-import \
+             --config \
+                 ./configs/netflow/${PREFIX}/CC/crosscalib_common.py \
+                 ./configs/netflow/SSP/CC/crosscalib_${FIELD}.py \
+             --exp-time ${EXP_TIME} \
+             --out "${IMPORT_DIR}" \
+             ${EXTRA_OPTIONS}
+     fi
+
+     if [ ! -d "$NETFLOW_DIR" ]; then
+         ga-netflow \
+             --config \
+                 ./configs/netflow/SSP/CC/crosscalib_common.py \
+                 ./configs/netflow/SSP/CC/crosscalib_${FIELD}.py \
+             --nvisits ${NVISITS} \
+             --exp-time ${EXP_TIME} \
+             --obs-time ${OBS_TIME} \
+             --in "${IMPORT_DIR}" \
+             --out "${NETFLOW_DIR}" \
+             ${EXTRA_OPTIONS}
+      fi
+
+     if [ ! -d "$EXPORT_DIR" ]; then
+         ga-export \
+             --in "${NETFLOW_DIR}" \
+             --out "$EXPORT_DIR" \
+             --input-catalog-id $INPUT_CATALOG_ID \
+             --proposal-id "$PROPOSAL_ID" \
+             --nframes $NFRAMES \
+             --obs-run "$OBS_RUN" \
+             ${EXTRA_OPTIONS}
+     fi
+
+ done
+
+
+# Clean up spt_ssp_observation
+
+# rm ${SSP_OBS_PATH}/runs/${OBS_RUN}/pfs_designs/GA/*.fits
+# rm ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/fluxstd/*.ecsv
+# rm ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/science/*.ecsv
+# rm ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/sky/*.ecsv
+# rm ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv
+
+
+# Copy target lists, design files and concatenate the ppcList.ecsv file
+
+#for FIELD in $FIELDS; do
+
+#    FIELD_DIR=$PFS_TARGETING_DATA/data/targeting/CC/crosscalib_${FIELD}
+#    EXPORT_DIR=${FIELD_DIR}/export/crosscalib_${FIELD}_${NVISITS}_${PREFIX}_${VERSION}
+
+    # Copy from the export dir to the spt_ssp_observation dir
+#    echo "Copying ${FIELD} files to ${SSP_OBS_PATH}"
+#    cp -R ${EXPORT_DIR}/runs ${SSP_OBS_PATH}
+
+    # # Concatenate the ppcList.ecsv files
+    # if [ ! -f ${EXPORT_DIR}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv ]; then
+    #     echo "File ${EXPORT_DIR}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv does not exist"
+    # else
+    #     echo "Concatenating ${EXPORT_DIR}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv to ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv"
+    #     cat ${EXPORT_DIR}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv >> ${SSP_OBS_PATH}/runs/${OBS_RUN}/targets/GA/ppcList.ecsv
+    # fi
+#done


### PR DESCRIPTION
Config files for the four cross-calibration fields have been updated:

crosscalib_ra288_dec-11
crosscalib_ra288_dec-17
crosscalib_ra288_dec-22
crosscalib_ra336_dec-12

To reduce the number of unassigned fibers, filler targets from Gaia have been added.
For the three ra288 fields, which lie toward low Galactic latitude, the flux standards from PS1 that are usually selected with
mask = 'lambda df: df["prob_f_star"] > 0.5'
are not available. Instead, an alternative selection,
mask = 'lambda df: df["is_fstar_gaia"] == True',
has been applied.